### PR TITLE
Fix --dump-toc-raw option

### DIFF
--- a/xar/src/xar.c
+++ b/xar/src/xar.c
@@ -1618,7 +1618,7 @@ static int dump_header(const char *filename) {
 
 static int dumptoc_raw(const char *filename, const char* tocfile) {
 	int fd, toc;
-	xar_header_ex_t xh;
+	xar_header_t xh;
 	uint64_t clen;
 	uint16_t hlen;
 	unsigned buffer_size = 4096;


### PR DESCRIPTION
This option was reading the correct number of bytes but
from the wrong starting offset within the xar file.

The --dump-toc-raw option always read at least the
first sizeof(xar_header_ex_t) bytes from the file before
reading header.toc_length_compressed bytes of data for
the TOC header.

However, sizeof(xar_header_ex_t) is the _maximum_ possible
size of the header. The minimum size is sizeof(xar_header_t).
The option then reads any additional bytes needed to position
the fd at header.size bytes from the beginning of the file.
