### PR TITLE
Add function to extract to external buffer.

### DIFF
--- a/xar/include/xar.h.in
+++ b/xar/include/xar.h.in
@@ -189,7 +189,9 @@ xar_file_t xar_add_from_archive(xar_t x, xar_file_t parent, const char *name, xa
 int32_t xar_extract(xar_t x, xar_file_t f);
 int32_t xar_extract_tofile(xar_t x, xar_file_t f, const char *path);
 int32_t xar_extract_tobuffer(xar_t x, xar_file_t f, char **buffer);
+int32_t xar_extract_size_needed(xar_t x, xar_file_t f, size_t *size);
 int32_t xar_extract_tobuffersz(xar_t x, xar_file_t f, char **buffer, size_t *size);
+int32_t xar_extract_tobuffersz_external(xar_t x, xar_file_t f, char *buffer, size_t size);
 int32_t xar_extract_tostream_init(xar_t x, xar_file_t f, xar_stream *stream);
 int32_t xar_extract_tostream(xar_stream *stream);
 int32_t xar_extract_tostream_end(xar_stream *stream);


### PR DESCRIPTION
Hi @mackyle,

this changeset adds a function that can be used to pass an external buffer to extract a file to. We need this as we'd like to use an existing application-specific memory pooling system instead of libc's `malloc`.

Malte
