### PR TITLE
Check for null pointer

### DIFF
--- a/xar/lib/archive.c
+++ b/xar/lib/archive.c
@@ -1764,6 +1764,12 @@ static int32_t xar_unserialize(xar_t x) {
 					}
 
 					s = xar_subdoc_new(x, (const char *)name);
+					if( !s ) {
+						xmlFreeTextReader(reader);
+						xmlDictCleanup();
+						xmlCleanupCharEncodingHandlers();
+						return -1;
+					}
 					XAR_SUBDOC(s)->attrs = attrs;
 					xar_subdoc_unserialize(s, reader);
 				}


### PR DESCRIPTION
Adds a check for a null pointer after attempting to initialize a new subdocument when decompressing a file.

Attached is a file that triggers a segfault without the null check. (Ignore the .txt extension, which is only there to make GitHub happy.)

[xar_subdoc_new_null_pointer_segfault.xar.txt](https://github.com/mackyle/xar/files/187289/xar_subdoc_new_null_pointer_segfault.xar.txt)
