### PR TITLE
Add several NULL checks for xar_file_t->fspath.

### DIFF
--- a/xar/lib/archive.c
+++ b/xar/lib/archive.c
@@ -1541,6 +1541,8 @@ int32_t xar_extract(xar_t x, xar_file_t f) {
 	const char *fspath;
 
 	fspath = XAR_FILE(f)->fspath;
+	if( !fspath )
+		return -1;
 	if (XAR(x)->stripcomps && (fspath=xar_strip_components(fspath, XAR(x)->stripcomps)) == NULL)
 		return -1;
 	if (XAR(x)->tostdout) {
@@ -1556,6 +1558,11 @@ int32_t xar_extract(xar_t x, xar_file_t f) {
 	}
 	else {
 		if( (strstr(fspath, "/") != NULL) && (stat(fspath, &sb)) && (XAR_FILE(f)->parent_extracted == 0) ) {
+			if( !XAR_FILE(f)->fspath ) {
+				xar_err_set_string(x, "Unable to retrieve filename");
+				xar_err_callback(x, XAR_SEVERITY_NONFATAL, XAR_ERR_ARCHIVE_EXTRACTION);
+				return -1;
+			}
 			tmp1 = strdup(XAR_FILE(f)->fspath);
 			dname = dirname(tmp1);
 			tmpf = xar_file_find(XAR(x)->files, dname);

--- a/xar/lib/util.c
+++ b/xar/lib/util.c
@@ -92,6 +92,10 @@ char *xar_get_path(xar_file_t f) {
 	xar_file_t i;
 
 	xar_prop_get(f, "name", &name);
+	if( !name ) {
+		asprintf(&ret, "");
+		return ret;
+	}
 	ret = strdup(name);
 	for(i = XAR_FILE(f)->parent; i; i = XAR_FILE(i)->parent) {
 		int err;


### PR DESCRIPTION
Adds a check for a null pointer in several places that access xar_file_t->fspath.

Attached is a file that triggers a segfault without the null checks. (Ignore the .txt extension, which is only there to make GitHub happy.)

[xar_file_t_fspath_null_pointer_segfault.xar.txt](https://github.com/mackyle/xar/files/188887/xar_file_t_fspath_null_pointer_segfault.xar.txt)
